### PR TITLE
Support for anchor links within newsletters

### DIFF
--- a/classes/NewsletterContent.php
+++ b/classes/NewsletterContent.php
@@ -409,7 +409,11 @@ class NewsletterContent extends \Newsletter {
 		return preg_replace_callback(
 			'/(\<a.*href\=")(.*)(")/Ui',
 			function($arrMatches) use ($intId, $strEmail, $strExtra) {
-				return $arrMatches[1] . \Environment::get('base') . 'tracking/?n=' . $intId . '&e=' . $strEmail . '&t=link&l=' . rtrim(strtr(base64_encode($arrMatches[2]), '+/', '-_'), '=') . $strExtra . $arrMatches[3];
+				if ( $arrMatches[2]{0} == "#") {
+					return $arrMatches[0];
+				} else {
+					return $arrMatches[1] . \Environment::get('base') . 'tracking/?n=' . $intId . '&e=' . $strEmail . '&t=link&l=' . rtrim(strtr(base64_encode($arrMatches[2]), '+/', '-_'), '=') . $strExtra . $arrMatches[3];
+				}
 			},
 			$strString
 		);


### PR DESCRIPTION
method prepareLinkTracking: 
prevent replacing links to anchors with tracking code
Verhindert, dass Links zu HTML-Ankern mit Tracking Code ersetzt werden