### PR TITLE
Replace \String with \StringUtils

### DIFF
--- a/TL_ROOT/system/modules/newsletter_content/classes/NewsletterContent.php
+++ b/TL_ROOT/system/modules/newsletter_content/classes/NewsletterContent.php
@@ -72,7 +72,7 @@ class NewsletterContent extends \Newsletter {
 
 		// Add default sender address
 		if ($objNewsletter->sender == '') {
-			list($objNewsletter->senderName, $objNewsletter->sender) = \String::splitFriendlyEmail($GLOBALS['TL_CONFIG']['adminEmail']);
+			list($objNewsletter->senderName, $objNewsletter->sender) = \StringUtil::splitFriendlyEmail($GLOBALS['TL_CONFIG']['adminEmail']);
 		}
 
 		$arrAttachments = array();
@@ -484,7 +484,7 @@ class NewsletterContent extends \Newsletter {
 	protected function sendNewsletter(\Email $objEmail, \Database\Result $objNewsletter, $arrRecipient, $text, $body, $css=null)
 	{
 		// Prepare the text content
-		$objEmail->text = \String::parseSimpleTokens($text, $arrRecipient);
+		$objEmail->text = \StringUtil::parseSimpleTokens($text, $arrRecipient);
 
 		// Add the HTML content
 		if (!$objNewsletter->sendText)

--- a/TL_ROOT/system/modules/newsletter_content/modules/ModuleNewsletterReader.php
+++ b/TL_ROOT/system/modules/newsletter_content/modules/ModuleNewsletterReader.php
@@ -80,10 +80,10 @@ class ModuleNewsletterReader extends \ModuleNewsletterReader {
 			
 			// Parse simple tokens and insert tags
 			$strContent = $this->replaceInsertTags($strContent);
-			$strContent = \String::parseSimpleTokens($strContent, array());
+			$strContent = \StringUtil::parseSimpleTokens($strContent, array());
 	
 			// Encode e-mail addresses
-			$strContent = \String::encodeEmail($strContent);
+			$strContent = \StringUtil::encodeEmail($strContent);
 
 			$this->Template->content = $strContent;
 		} else {
@@ -95,10 +95,10 @@ class ModuleNewsletterReader extends \ModuleNewsletterReader {
 
 		// Parse simple tokens and insert tags
 		$strContent = $this->replaceInsertTags($strContent);
-		$strContent = \String::parseSimpleTokens($strContent, array());
+		$strContent = \StringUtil::parseSimpleTokens($strContent, array());
 
 		// Encode e-mail addresses
-		$strContent = \String::encodeEmail($strContent);
+		$strContent = \StringUtil::encodeEmail($strContent);
 
 		$this->Template->content = $strContent;
 		$this->Template->subject = $objNewsletter->subject;


### PR DESCRIPTION
Using \String is deprecated and for PHP7 compatibility we have to replace everything with \StringUtils. See contao/core-bundle/issues/309