### PR TITLE
Backwards Compability to default Newsletter Module

### DIFF
--- a/TL_ROOT/system/modules/newsletter_content/classes/NewsletterContent.php
+++ b/TL_ROOT/system/modules/newsletter_content/classes/NewsletterContent.php
@@ -112,6 +112,11 @@ class NewsletterContent extends \Newsletter {
 			while ($objContentElements->next()) {
 				$html.= $this->getContentElement($objContentElements->id);
 			}
+		} else {
+			if (!defined('NEWSLETTER_CONTENT_PREVIEW')) {
+			    define('NEWSLETTER_CONTENT_PREVIEW', true);
+			}
+			$html = $objNewsletter->content;
 		}
 
 		// Replace insert tags

--- a/TL_ROOT/system/modules/newsletter_content/modules/ModuleNewsletterReader.php
+++ b/TL_ROOT/system/modules/newsletter_content/modules/ModuleNewsletterReader.php
@@ -76,6 +76,11 @@ class ModuleNewsletterReader extends \ModuleNewsletterReader {
 				foreach ($objContentElements as $objContentElement) {
 					$strContent.= $this->getContentElement($objContentElement->id);
 				}
+			} else {
+				if (!defined('NEWSLETTER_CONTENT_PREVIEW')) {
+				    define('NEWSLETTER_CONTENT_PREVIEW', true);
+				}
+				$strContent = $objNewsletter->content;
 			}
 			
 			// Parse simple tokens and insert tags


### PR DESCRIPTION
This PR makes the module compatible to the default Newsletter Module. If no content elements exist, it will just print the HTML Content. So it is possible to keep the old newsletter when switching to this module. This has no influence to newsletter where ContentElements are defined.