### PR TITLE
Fix error in strict mode

### DIFF
--- a/system/modules/newsletter_content/classes/NewsletterContent.php
+++ b/system/modules/newsletter_content/classes/NewsletterContent.php
@@ -233,6 +233,8 @@ class NewsletterContent extends \Newsletter {
 			if ($objRecipients->numRows < 1 || ($intStart + $intPages) >= $intTotal) {
 				$this->Session->set('tl_newsletter_send', null);
 
+				$intRejected = 0;
+
 				// Deactivate rejected addresses
 				if (!empty($_SESSION['REJECTED_RECIPIENTS']))
 				{


### PR DESCRIPTION
This fixes an error that can occur when the database is in strict mode (which is the default now). `$intRejected` might not be set and thus `null` would be inserted - which is not allowed by the database as the field `tl_newsletter.rejected` must be an integer and not null.